### PR TITLE
fix cursor on M1 Mac

### DIFF
--- a/libs/cursor.py
+++ b/libs/cursor.py
@@ -54,5 +54,6 @@ class cursor:
 
         mouseX, mouseY = self.config.get_mouse_pointer_pos()
         centerX, centerY = self.center[self.shape]
+        self.cursor_images.set_colorkey(0, RLEACCEL)
         self.screen.blit(self.cursor_images, (mouseX-(centerX*self.scaleX), (mouseY-(centerY*self.scaleY//2))*2), (16*self.shape*self.scaleX,0,16*self.scaleX,self.cursor_images.get_height()))
 


### PR DESCRIPTION

https://github.com/mriale/PyDPainter/assets/129693/d7b452a2-56dc-4897-a729-b353f091026f

I ran it on my M1 Mac and it worked.
However, the cursor color key was wrong.
So I specified the color key and it worked.
Thank you in advance for your help.
