### PR TITLE
If the maximum color index is less than the number of colors, do not quantize_palette.

### DIFF
--- a/libs/config.py
+++ b/libs/config.py
@@ -103,25 +103,30 @@ for r in range(2,30):
                                (g//2)*((g%2)*2-1), \
                                (b//2)*((b%2)*2-1)))
 
+colcache = {}
 def unique_palette(pal):
     newpal = []
     paldict = {}
     #print("len(pal): " + str(len(pal)))
     for i in range(0,len(pal)):
         col = pal[i]
-        j = 0
-        out_of_range = False
-        #print("color[" + str(i) + "]: " + str(col))
-        while out_of_range or str(col) in paldict:
-            #print("dup color: " + str(col))
+        if str(col) in colcache:
+            col = colcache[str(col)]
+        else:
+            j = 0
             out_of_range = False
-            r = pal[i][0] + color_skew[j][0]
-            g = pal[i][1] + color_skew[j][1]
-            b = pal[i][2] + color_skew[j][2]
-            if r < 0 or r > 255 or g < 0 or g > 255 or b < 0 or b > 255:
-                out_of_range = True
-            col = (r,g,b)
-            j = j + 1
+            #print("color[" + str(i) + "]: " + str(col))
+            while out_of_range or str(col) in paldict:
+                #print("dup color: " + str(col))
+                out_of_range = False
+                r = pal[i][0] + color_skew[j][0]
+                g = pal[i][1] + color_skew[j][1]
+                b = pal[i][2] + color_skew[j][2]
+                if r < 0 or r > 255 or g < 0 or g > 255 or b < 0 or b > 255:
+                    out_of_range = True
+                col = (r,g,b)
+                j = j + 1
+            colcache[str(col)]=col
         newpal.append(col)
         paldict[str(col)] = 1
     #pal256.extend([pal[0]] * (256-len(pal)))

--- a/libs/menureq.py
+++ b/libs/menureq.py
@@ -620,6 +620,14 @@ Resize Page: [Yes~No]
 
         return newpal
 
+    def get_max_color_index():
+        max_color_index = 0
+        for y in range(config.pixel_canvas.get_height()):
+            for x in range(config.pixel_canvas.get_width()):
+                color_index = config.pixel_canvas.get_at_mapped((x,y))
+                if max_color_index < color_index:
+                    max_color_index = color_index
+        return max_color_index
 
     req.center(screen)
     config.pixel_req_rect = req.get_screen_rect()
@@ -692,21 +700,26 @@ Resize Page: [Yes~No]
                             if halfbright:
                                 num_top_colors = 32
 
-                            colorlist = get_top_colors(num_top_colors)
+                            if get_max_color_index() < num_colors:
+                                config.truepal = config.truepal[0:num_colors]
+                                config.pal = config.pal[0:num_colors]
+                            else:
+                                colorlist = get_top_colors(num_top_colors)
 
-                            newpal = get_top_pal(config.pal, colorlist, num_colors, halfbright)
+                                newpal = get_top_pal(config.pal, colorlist, num_colors, halfbright)
 
-                            #convert colors to reduced palette using blit
-                            new_pixel_canvas = pygame.Surface((config.pixel_width, config.pixel_height),0,8)
-                            new_pixel_canvas.set_palette(newpal)
-                            new_pixel_canvas.blit(config.pixel_canvas, (0,0))
+                                #convert colors to reduced palette using blit
+                                new_pixel_canvas = pygame.Surface((config.pixel_width, config.pixel_height),0,8)
+                                new_pixel_canvas.set_palette(newpal)
+                                new_pixel_canvas.blit(config.pixel_canvas, (0,0))
 
-                            #substitute new canvas for the higher color one
-                            config.pixel_canvas = new_pixel_canvas
-                            config.truepal = get_top_pal(config.truepal, colorlist, num_colors, halfbright)[0:num_colors]
-                            config.truepal = config.quantize_palette(config.truepal, cdepth)
-                            config.pal = list(config.truepal)
-                            config.pal = config.unique_palette(config.pal)
+                                #substitute new canvas for the higher color one
+                                config.pixel_canvas = new_pixel_canvas
+                                config.truepal = get_top_pal(config.truepal, colorlist, num_colors, halfbright)[0:num_colors]
+                                config.truepal = config.quantize_palette(config.truepal, cdepth)
+                                config.pal = list(config.truepal)
+                                config.pal = config.unique_palette(config.pal)
+
                             config.backuppal = list(config.pal)
                             config.pixel_canvas.set_palette(config.pal)
                             for frame in config.anim.frame:


### PR DESCRIPTION
For example, when SCREEN FORMAT is changed from 256 to 64 colors, I do not want the order of the palette to change even though only 64 colors were originally used.
So, we find the maximum index in the image and if that number is less than the new number of palettes, then we do not change it.
