### PR TITLE
picio: Fix recovery load: Pass existing pic into load_iff when updating with .iffinfo file

### DIFF
--- a/libs/picio.py
+++ b/libs/picio.py
@@ -161,9 +161,8 @@ class Chunk(object):
             self.iff_file.seek(1, 1) #make sure word-aligned
 
 #read in an IFF file
-def load_iff(filename, config, ifftype):
+def load_iff(filename, config, ifftype, pic = None):
     cranges = []
-    pic = None
     display_mode = -1
     try:
         iff_file = open(filename,'rb')
@@ -591,7 +590,7 @@ def load_pygame_pic(filename, config, status_func=None, force_pal=None):
 
     iffinfo_file = re.sub(r"\.[^.]+$", ".iffinfo", filename)
     if pic_type(iffinfo_file) == "ILBM":
-        load_iff(iffinfo_file, config, "ILBM")
+        load_iff(iffinfo_file, config, "ILBM", pic)
     else:
         config.display_mode = -1
 


### PR DESCRIPTION
This PR is to fix a crash when requesting PyDPainter to load a saved recovery image dumped on a prior crash. 

>   _(Incidentally: The prior crash was due to [enabling a stencil on a larger-than-screen image](https://github.com/mriale/PyDPainter/pull/189) but I'm not sure whether that's relevant to this PR.  Though maybe the image size is, as the failing code below was in a width-sensitive block.)_

During recovery, after an image is selected to recover, PyDPainter reads the selected BMP OK, and then starts to parse the extra `.iffinfo` file.  This then fails to apply the palette in `load_iff` here
```python
    #crop image to actual bitmap size
    if w != w2b(w)*8:
        newpic = pygame.Surface((w, h), 0, pic)
        newpic.set_palette(config.pal)
        newpic.blit(pic, (0,0))
        return newpic
```
Since there is no `pic`, the `newpic` surface is created in rgb format not indexed, so `set_palette` throws.

Passing the `pic` loaded by the caller (`load_pygame_pic`) resolves the issue, and defaulting it to `None` maintains compatibility with any other call sites.