### PR TITLE
stencil: Don't extend clip mask bounds below 0,0 in visible space

### DIFF
--- a/libs/stencil.py
+++ b/libs/stencil.py
@@ -117,8 +117,8 @@ class Stencil:
             m += offset
 
             #clip mask to drawing area
-            m = m[ (m[:,0] >= offset[0]) & (m[:,0] <= screen_size[0]) &
-                   (m[:,1] >= offset[1]) & (m[:,1] <= screen_size[1]) ]
+            m = m[ (m[:,0] >= 0) & (m[:,0] <= screen_size[0]) &
+                   (m[:,1] >= 0) & (m[:,1] <= screen_size[1]) ]
             m = m.transpose()
             mask_offset = tuple(m)
 


### PR DESCRIPTION
When applying a stencil to an image larger than the visible screen, and the screen is offset, the render mask erroneously considers indices from the back of the mask as well as the visible area.

This does not crash if the image is up-to double in size, since Python's negative indexing ends up looking in valid cells (although erroneous ones).  But if the image is more than double in a dimension, when scrolling to that extent, the code attempts to access a negative index larger in magnitude than the array length.

Since the mask `m` is already offset by `offset`, I think it only needs to be limited to `0, 0` rather than `offset`.

This appears to work for my use case of a very large image when panning with a stencil active.
