### PR TITLE
Initial experimental paste text support #31

### DIFF
--- a/libs/config.py
+++ b/libs/config.py
@@ -196,8 +196,7 @@ class pydpainter:
         #initialize system
         self.dinfo = pygame.display.Info()
         self.initialize()
-        pygame.scrap.init()
-        pygame.scrap.set_mode(pygame.SCRAP_CLIPBOARD)
+        clipboard_init()  # tools.clipboard_init()
 
         #load picture if recovered
         if do_recover != "":

--- a/libs/config.py
+++ b/libs/config.py
@@ -196,6 +196,8 @@ class pydpainter:
         #initialize system
         self.dinfo = pygame.display.Info()
         self.initialize()
+        pygame.scrap.init()
+        pygame.scrap.set_mode(pygame.SCRAP_CLIPBOARD)
 
         #load picture if recovered
         if do_recover != "":

--- a/libs/tools.py
+++ b/libs/tools.py
@@ -1475,11 +1475,11 @@ class DoText(ToolSingleAction):
         if self.pos == None:
             return False
 
-        if mod & KMOD_CTRL and key == K_v:
+        if (mod & KMOD_CTRL and key == K_v) or (mod & KMOD_SHIFT and key == K_INSERT):
             clipboard_text = clipboard_get_text()
 
             if clipboard_text:
-                self.text = self.text + clipboard_text  # This works ... but get trailing squarebox
+                self.text = self.text + clipboard_text  # This works ... but get trailing squarebox for CTRL-V, but not SHIFT-Insert
         elif mod & KMOD_CTRL or mod & KMOD_ALT or mod & KMOD_META:
             return False
 

--- a/libs/tools.py
+++ b/libs/tools.py
@@ -33,10 +33,8 @@ def clipboard_init():
 def clipboard_get_text():
     if is_pygamece:
         # pygame-ce
-        print('pygame-ce')
         clipboard_text = pygame.scrap.get_text()
     else:
-        print('pygame')
         # pygame
         for t in pygame.scrap.get_types():
             if "text" in t and pygame.scrap.get(t) != None:  # probably; 'text/plain;charset=utf-8'

--- a/libs/tools.py
+++ b/libs/tools.py
@@ -1438,6 +1438,20 @@ class DoText(ToolSingleAction):
         if self.pos == None:
             return False
 
+        if mod & KMOD_CTRL and key == K_v:
+            clipboard_text = None
+            #clipboard_text = pygame.scrap.get('text/plain;charset=utf-8')
+            for t in pygame.scrap.get_types():
+                if "text" in t and pygame.scrap.get(t) != None:  # probably; 'text/plain;charset=utf-8'
+                    #clipboard_text = pygame.scrap.get(t).decode("utf-8")
+                    clipboard_text = pygame.scrap.get(t).decode("utf-16-le")  # under windows its utf16-le! and NUL terminated..
+            if clipboard_text:
+                if clipboard_text.endswith('\x00'):
+                    clipboard_text = clipboard_text[:-1]
+
+            if clipboard_text:
+                self.text = self.text + clipboard_text  # This works ... but no preview on screen...
+
         if mod & KMOD_CTRL or mod & KMOD_ALT or mod & KMOD_META:
             return False
 

--- a/libs/tools.py
+++ b/libs/tools.py
@@ -1479,7 +1479,8 @@ class DoText(ToolSingleAction):
             clipboard_text = clipboard_get_text()
 
             if clipboard_text:
-                self.text = self.text + clipboard_text  # This works ... but get trailing squarebox for CTRL-V, but not SHIFT-Insert
+                self.text = self.text + clipboard_text
+                unicode = ''  # avoid duplicate concat
         elif mod & KMOD_CTRL or mod & KMOD_ALT or mod & KMOD_META:
             return False
 

--- a/libs/tools.py
+++ b/libs/tools.py
@@ -8,6 +8,11 @@ with contextlib.redirect_stdout(None):
     import pygame
     from pygame.locals import *
 
+try:
+    import xerox  # NOTE use https://github.com/clach04/xerox/  -- python -m pip install git+https://github.com/clach04/xerox.git
+except ImportError:
+    xerox = None
+
 from libs.toolbar import *
 from libs.toolreq import *
 from libs.gadget import *
@@ -31,7 +36,9 @@ def clipboard_init():
         pygame.scrap.set_mode(pygame.SCRAP_CLIPBOARD)
 
 def clipboard_get_text():
-    if is_pygamece:
+    if xerox:
+        clipboard_text = xerox.paste()
+    elif is_pygamece:
         # pygame-ce
         clipboard_text = pygame.scrap.get_text()
     else:

--- a/libs/tools.py
+++ b/libs/tools.py
@@ -1442,9 +1442,8 @@ class DoText(ToolSingleAction):
             clipboard_text = pygame.scrap.get_text()
 
             if clipboard_text:
-                self.text = self.text + clipboard_text  # This works ... but no preview on screen...
-
-        if mod & KMOD_CTRL or mod & KMOD_ALT or mod & KMOD_META:
+                self.text = self.text + clipboard_text  # This works ... but get trailing squarebox
+        elif mod & KMOD_CTRL or mod & KMOD_ALT or mod & KMOD_META:
             return False
 
         ax = 1

--- a/libs/tools.py
+++ b/libs/tools.py
@@ -1439,15 +1439,7 @@ class DoText(ToolSingleAction):
             return False
 
         if mod & KMOD_CTRL and key == K_v:
-            clipboard_text = None
-            #clipboard_text = pygame.scrap.get('text/plain;charset=utf-8')
-            for t in pygame.scrap.get_types():
-                if "text" in t and pygame.scrap.get(t) != None:  # probably; 'text/plain;charset=utf-8'
-                    #clipboard_text = pygame.scrap.get(t).decode("utf-8")
-                    clipboard_text = pygame.scrap.get(t).decode("utf-16-le")  # under windows its utf16-le! and NUL terminated..
-            if clipboard_text:
-                if clipboard_text.endswith('\x00'):
-                    clipboard_text = clipboard_text[:-1]
+            clipboard_text = pygame.scrap.get_text()
 
             if clipboard_text:
                 self.text = self.text + clipboard_text  # This works ... but no preview on screen...

--- a/libs/tools.py
+++ b/libs/tools.py
@@ -1480,34 +1480,33 @@ class DoText(ToolSingleAction):
 
             if clipboard_text:
                 self.text = self.text + clipboard_text
-                unicode = ''  # avoid duplicate concat
         elif mod & KMOD_CTRL or mod & KMOD_ALT or mod & KMOD_META:
             return False
-
-        ax = 1
-        ay = 1
-        if config.aspectX != config.aspectY:
-            if config.aspectX == 2:
-                ay = 2
-            else:
-                ax = 2
-
-        if key == K_BACKSPACE:
-            self.text = self.text[:-1]
-        elif key == K_RETURN:
-            pos = self.pos
-            self.stamptext()
-            self.pos = [pos[0], pos[1]+(self.fontsize[1]//ay)]
-        elif key == K_ESCAPE:
-            self.stamptext()
-            config.toolbar.click(config.toolbar.tool_id("draw"), MOUSEBUTTONDOWN)
-            return True
-        elif key == K_TAB:
-            pass
-        elif key == K_DELETE:
-            pass
         else:
-            self.text += unicode
+            ax = 1
+            ay = 1
+            if config.aspectX != config.aspectY:
+                if config.aspectX == 2:
+                    ay = 2
+                else:
+                    ax = 2
+
+            if key == K_BACKSPACE:
+                self.text = self.text[:-1]
+            elif key == K_RETURN:
+                pos = self.pos
+                self.stamptext()
+                self.pos = [pos[0], pos[1]+(self.fontsize[1]//ay)]
+            elif key == K_ESCAPE:
+                self.stamptext()
+                config.toolbar.click(config.toolbar.tool_id("draw"), MOUSEBUTTONDOWN)
+                return True
+            elif key == K_TAB:
+                pass
+            elif key == K_DELETE:
+                pass
+            else:
+                self.text += unicode
 
         config.clear_pixel_draw_canvas()
         self.drawtext(self.pos)


### PR DESCRIPTION
This needs discussion and refinement before merging. EDIT and remove this before merging

Outstanding items:

 - [x] https://github.com/clach04/xerox/
 - [x] pygame-ce API usage
 - [x] pygame API fallback
 - [x] paste visualization
 - [x] small squarebox displayed in preview for CTRL-V (only), not an issue for Shift-Insert
 - [x] determine old code status, comment out code path never encountered. Should this be removed (if so, in a separate change?), see https://github.com/mriale/PyDPainter/blob/89a768afd915dc2a2a5c3da44b199ec212815c71/libs/gadget.py#L543
 - [ ] refactor, discussion https://github.com/mriale/PyDPainter/pull/207#discussion_r1938551956
 - [ ] possible newline support? Under discussion. Behavior still to be decided/designed
